### PR TITLE
Handle multiple create events and monitor Public\Desktop

### DIFF
--- a/DesktopCop/Program.cs
+++ b/DesktopCop/Program.cs
@@ -13,14 +13,23 @@ namespace DesktopCop
             
             var desktopDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.Desktop));
             var deskopDirectoryPath = desktopDirectory.FullName;
-            
+
+            var publicDesktopDirectory = new DirectoryInfo(Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory));
+            var publicDesktopDirectoryPath = publicDesktopDirectory.FullName;
+
             // Create a FileWatcher to monitor for items added to the Dekstop.
             Console.WriteLine($"Monitoring {deskopDirectoryPath}");
-            
+            Console.WriteLine($"Monitoring {publicDesktopDirectoryPath}");
+
             var fileSystemWatcher = new FileSystemWatcher();
             fileSystemWatcher.Path = deskopDirectoryPath;
             fileSystemWatcher.Created += FileSystemWatcher_Created;
             fileSystemWatcher.EnableRaisingEvents = true;
+
+            var publicFileSystemWatcher = new FileSystemWatcher();
+            publicFileSystemWatcher.Path = publicDesktopDirectoryPath;
+            publicFileSystemWatcher.Created += FileSystemWatcher_Created;
+            publicFileSystemWatcher.EnableRaisingEvents = true;
 
             // Run the program forever by waiting on an event which will never happen.
             Console.WriteLine("Entering Blocking State");
@@ -36,28 +45,33 @@ namespace DesktopCop
         private static void FileSystemWatcher_Created(object sender, FileSystemEventArgs e)
         {
             Console.WriteLine($"File {e.Name} Created");
-            
-            // Confirm the file meets substring requirements.
-            if(e.Name.Length > 4)
-            {
-                // Extract the last four characters of the file name to determin file type.
-                var fileEnding = e.Name.Substring(e.Name.Length - 4).ToLower();
-                Console.WriteLine($"File Type {fileEnding} Discovered");
 
-                // Remove offending files.
-                switch (fileEnding)
-                {
-                    case ".lnk":
-                    case ".url":
+            // Get File Extension to Determine Type
+            string fileEnding = Path.GetExtension(e.Name);
+
+            Console.WriteLine($"File Type {fileEnding} Discovered");
+
+            // Remove offending files.
+            switch (fileEnding)
+            {
+                case ".lnk":
+                case ".url":
+                    bool tryagain = true;
+                    while (tryagain)
                     {
                         if (File.Exists(e.FullPath))
                         {
                             Console.WriteLine($"Removing {e.Name}");
-                            File.Delete(e.FullPath);
+                            try
+                            {
+                                File.Delete(e.FullPath);
+                                tryagain = false; //We Have Deleted The File
+                            }
+                            catch (System.IO.IOException) { } //The Created Event is not guaranteed to be raised exactly once. These leads to a race condition.
                         }
-                        break;
+                        else { tryagain = false; } //File No Longer Exists
                     }
-                }
+                    break;
             }
         }
     }


### PR DESCRIPTION
Apparently, it is a well known "issue" that the FileSystemWatcher (sometimes) raises multiple events. This combined with how copy operations work, I believe is leading to a race condition.

The work around is to effectively eat the IOException and try again. The edge case that I'm aware of is file not found, which is why we verify that the path is valid each attempt.

We monitor Public\Desktop the same way as %USER%\Desktop